### PR TITLE
Override erlang-dbus hardcoded cookie

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ExDbus.MixProject do
   def project do
     [
       app: :ex_dbus,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: ">= 1.11.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
erlang-dbus passes hex encoded UID "1000" which breaks D-Bus authentication for root (and other UID users)
This PR allows passing an optional `:cookie` value or `:system_user` value to read the following environment variables:
- `UID` - if present, sets the cookie to the Base.encode16/1 of the value
- `USER - if no `UID` env variable is present, retrieve the `USER` env variable and execute `id -u <USER>` to retrieve the UID of the username, then encode that with Base.encode16/1 and set `Application.put_env(:dbus, :external_cookie, uid)` so that erlang-dbus uses that for `EXTERNAL` auth instead of the default encoded `1000`